### PR TITLE
fix iterator allocs when using with foreach

### DIFF
--- a/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeArray.Iterator.cs
+++ b/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeArray.Iterator.cs
@@ -73,7 +73,11 @@ namespace Collections.Unsafe {
       public void Dispose() {
       }
 
-      public IEnumerator<T> GetEnumerator() {
+      public Iterator<T> GetEnumerator() {
+        return this;
+      }
+
+      IEnumerator<T> IEnumerable<T>.GetEnumerator() {
         return this;
       }
 

--- a/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeList.Iterator.cs
+++ b/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeList.Iterator.cs
@@ -76,7 +76,11 @@ namespace Collections.Unsafe {
       public void Dispose() {
       }
 
-      public IEnumerator<T> GetEnumerator() {
+      public Iterator<T> GetEnumerator() {
+        return this;
+      }
+
+      IEnumerator<T> IEnumerable<T>.GetEnumerator() {
         return this;
       }
 


### PR DESCRIPTION
With this the compiler can duck type, avoiding the boxing alloc from GetEnumerator