### PR TITLE
feat (UnsafeList): Insert item at index

### DIFF
--- a/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeHashCollection.cs
+++ b/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeHashCollection.cs
@@ -148,7 +148,8 @@ namespace Collections.Unsafe {
     }
 
     public static Entry* Find<T>(UnsafeHashCollection* collection, T value, int valueHash) where T : unmanaged, IEquatable<T> {
-      var bucketHead = collection->Buckets[valueHash % collection->Entries.Length];
+      uint bucketHash = (uint)valueHash % (uint)collection->Entries.Length;
+      var bucketHead = collection->Buckets[bucketHash];
 
       while (bucketHead != null) {
         if (bucketHead->Hash == valueHash && value.Equals(*(T*)((byte*)bucketHead + collection->KeyOffset))) {
@@ -163,8 +164,8 @@ namespace Collections.Unsafe {
     }
 
     public static bool Remove<T>(UnsafeHashCollection* collection, T value, int valueHash) where T : unmanaged, IEquatable<T> {
-      var bucketHash = valueHash % collection->Entries.Length;
-      var bucketHead = collection->Buckets[valueHash % collection->Entries.Length];
+      uint bucketHash = (uint)valueHash % (uint)collection->Entries.Length;
+      var bucketHead = collection->Buckets[bucketHash];
       var bucketPrev = default(Entry*);
 
       while (bucketHead != null) {
@@ -237,7 +238,7 @@ namespace Collections.Unsafe {
       }
 
       // compute bucket hash
-      var bucketHash = valueHash % collection->Entries.Length;
+      uint bucketHash = (uint)valueHash % (uint)collection->Entries.Length;
 
       // hook up entry
       entry->Hash  = valueHash;
@@ -285,7 +286,7 @@ namespace Collections.Unsafe {
       for (int i = collection->Entries.Length - 1; i >= 0; --i) {
         var entry = (Entry*)((byte*)newEntries.Ptr + (i * newEntries.Stride));
         if (entry->State == EntryState.Used) {
-          var bucketHash = entry->Hash % capacity;
+          uint bucketHash = (uint)entry->Hash % (uint)capacity;
 
           // assign current entry in buckets as next
           entry->Next = newBuckets[bucketHash];

--- a/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeList.cs
+++ b/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeList.cs
@@ -72,6 +72,8 @@ namespace Collections.Unsafe {
     }
     
     public static void Free(UnsafeList* list) {
+      if(list->_items.Dynamic == 1)
+        UnsafeBuffer.Free(&list->_items);
       Native.Free(list);
     }
 

--- a/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeList.cs
+++ b/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeList.cs
@@ -182,6 +182,43 @@ namespace Collections.Unsafe {
       list->_count = count + 1;
     }
 
+    public static void Insert<T>(UnsafeList* list, int index, T item) where T : unmanaged {
+      Assert.Check(list != null);
+
+      var count = list->_count;
+      var items = list->_items;
+
+      // cast to uint trick, which eliminates < 0 check
+      if ((uint)index > (uint)count)
+      {
+          throw new IndexOutOfRangeException();
+      }
+
+      if (count >= items.Length)
+      {
+          if (items.Dynamic == 0)
+          {
+              throw new InvalidOperationException(LIST_FULL);
+          }
+
+          // double capacity, make sure that if length is 0 then we set capacity to at least 2
+          SetCapacity(list, Math.Max(2, items.Length * 2));
+
+          // re-assign items after expand
+          items = list->_items;
+
+          Assert.Check(count < items.Length);
+      }
+
+      if(index < count)
+      {
+          UnsafeBuffer.Move(items, index, index + 1, count - index);
+      }
+
+      *(T*)UnsafeBuffer.Element(items.Ptr, index, items.Stride) = item;
+      list->_count = count + 1;
+    }
+
     public static void Set<T>(UnsafeList* list, int index, T item) where T : unmanaged {
       Assert.Check(list != null);
 

--- a/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeStack.cs
+++ b/UnsafeCollections/Assets/UnsafeCollections/Collections/UnsafeStack.cs
@@ -29,7 +29,6 @@ namespace Collections.Unsafe {
     const string STACK_FULL = "Fixed size stack is full";
 
     UnsafeBuffer _items;
-    IntPtr       _typeKey;
     int          _count;
 
     public static UnsafeStack* Allocate<T>(int capacity, bool fixedSize = false) where T : unmanaged {


### PR DESCRIPTION
Added insert functionality.

In theory this could be done more efficiently in the case where the array grows, since both the insertion operation and SetCapacity move memory. Not sure if it's worth it to add this complexity to the code though, since typically allocating memory is already quite slow anyway.